### PR TITLE
Extends compatible host platforms.

### DIFF
--- a/includes/class-migration-checks.php
+++ b/includes/class-migration-checks.php
@@ -31,7 +31,7 @@ class BH_Site_Migrator_Migration_Checks {
 	 * Register migration checks.
 	 */
 	public static function register() {
-		add_filter( 'bluehost_site_migrator_can_migrate', array( __CLASS__, 'can_mysqldump' ), 5 );
+		//add_filter( 'bluehost_site_migrator_can_migrate', array( __CLASS__, 'can_mysqldump' ), 5 );
 		add_filter( 'bluehost_site_migrator_can_migrate', array( __CLASS__, 'can_we_migrate_api' ), 10 );
 		add_filter( 'bluehost_site_migrator_can_migrate', array( __CLASS__, 'has_zip_archive' ), 5 );
 		add_filter( 'bluehost_site_migrator_can_migrate', array( __CLASS__, 'is_content_directory_writable' ), 5 );


### PR DESCRIPTION
## Proposed changes

The Bluehost-Site-Migrator plugin is unable to migrate websites that does not have mysqldump. There is also an additional logic tree that aborts the migration if mysqldump fails. I have a proposed change which would allow the migration to continue in both cases by utilizing a backup method to dump the database. The alternate method of dumping the database is located in the BH_Site_Migrator_Database_Packager::get_sql_dump_legacy();

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
