### PR TITLE
Fix GitHub Action deprecated notices.

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -80,7 +80,7 @@ jobs:
               run: echo '{"plugins":["${{ steps.workflow.outputs.DIST }}/${{ steps.workflow.outputs.PACKAGE }}"]}' > .wp-env.override.json
 
             - name: Install WordPress
-              run: yarn wp-env start
+              run: npx wp-env start
 
             - name: Run Cypress Tests
               run: yarn run test

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -41,7 +41,7 @@ jobs:
 
             - name: Get Composer cache directory
               id: composer-cache
-              run: echo ""dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache Composer vendor directory
               uses: actions/cache@v3

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -30,8 +30,8 @@ jobs:
                   REPO: ${{ github.repository }}
               run: |
                   mkdir dist
-                  echo ::set-output name=DIST::${PWD}/dist
-                  echo ::set-output name=PACKAGE::${REPO##*/}
+                  echo "DIST=${PWD}/dist" >> $GITHUB_OUTPUT
+                  echo "PACKAGE=${REPO##*/}" >> $GITHUB_OUTPUT
 
             - name: Use Node.js 18.x
               uses: actions/setup-node@v3
@@ -41,7 +41,7 @@ jobs:
 
             - name: Get Composer cache directory
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo ""dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache Composer vendor directory
               uses: actions/cache@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
 
             - name: Get Composer Cache Directory
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache Composer vendor directory
               uses: actions/cache@v3

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -15,11 +15,11 @@ jobs:
         id: package
         env:
           REPO: ${{ github.repository }}
-        run: echo ::set-output name=PACKAGE::${REPO##*/}
+        run: echo "PACKAGE=${REPO##*/}" >> $GITHUB_OUTPUT
 
       - name: Set Version
         id: tag
-        run: echo ::set-output name=VERSION::${GITHUB_REF##*/}
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/svn-deploy-plugin-on-release.yml
+++ b/.github/workflows/svn-deploy-plugin-on-release.yml
@@ -17,7 +17,7 @@ jobs:
               id: package
               env:
                   REPO: ${{ github.repository }}
-              run: echo ::set-output name=PACKAGE::${REPO##*/}
+              run: echo "PACKAGE=${REPO##*/}" >> $GITHUB_OUTPUT
 
             - name: PHP version
               run: php --version
@@ -45,7 +45,7 @@ jobs:
 
             - name: Get Composer Cache Directory
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache Composer vendor directory
               uses: actions/cache@v3

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -20,8 +20,8 @@ jobs:
                   REPO: ${{ github.repository }}
               run: |
                   mkdir dist
-                  echo ::set-output name=DIST::${PWD}/dist
-                  echo ::set-output name=PACKAGE::${REPO##*/}
+                  echo "DIST=${PWD}/dist" >> $GITHUB_OUTPUT
+                  echo "PACKAGE=${REPO##*/}" >> $GITHUB_OUTPUT
 
             - name: PHP version
               run: php --version
@@ -49,7 +49,7 @@ jobs:
 
             - name: Get Composer Cache Directory
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache Composer vendor directory
               uses: actions/cache@v3

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -20,8 +20,8 @@ jobs:
                   REPO: ${{ github.repository }}
               run: |
                   mkdir dist
-                  echo ::set-output name=DIST::${PWD}/dist
-                  echo ::set-output name=PACKAGE::${REPO##*/}
+                  echo "DIST=${PWD}/dist" >> $GITHUB_OUTPUT
+                  echo "PACKAGE=${REPO##*/}" >> $GITHUB_OUTPUT
 
             - name: PHP version
               run: php --version
@@ -49,7 +49,7 @@ jobs:
 
             - name: Get Composer Cache Directory
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache Composer vendor directory
               uses: actions/cache@v3


### PR DESCRIPTION
This fixes several deprecated notices caused by the use of `set-output` and `save-output` in GitHub Action workflows.

These were deprecated, and could be removed at any time without notice. GitHub posted an update on July 24th that they still plan on removing these commands but were delaying the removal because of continued high usage.

More can be found about this in the announcement posts:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/