### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,6 +23,7 @@ jobs:
     test:
         name: Run Cypress Tests
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         permissions:
             contents: read # Required for actions/checkout to clone the repository.
         steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,10 +15,16 @@ on:
     pull_request_review:
         types: [submitted, edited]
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
     test:
         name: Run Cypress Tests
         runs-on: ubuntu-latest
+        permissions:
+            contents: read # Required for actions/checkout to clone the repository.
         steps:
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,15 @@ on:
         paths:
             - '**.php'
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
     phpcs:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read # Required for actions/checkout to clone the repository.
         steps:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ permissions: {}
 jobs:
     phpcs:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         permissions:
             contents: read # Required for actions/checkout to clone the repository.
         steps:

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -13,6 +13,7 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions: {} # No GITHUB_TOKEN access required; cross-repo dispatch uses a separate WEBHOOK_TOKEN secret.
     steps:
 

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -5,10 +5,15 @@ on:
     types:
       - published
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # No GITHUB_TOKEN access required; cross-repo dispatch uses a separate WEBHOOK_TOKEN secret.
     steps:
 
       - name: Set Package

--- a/.github/workflows/svn-deploy-assets-on-push.yml
+++ b/.github/workflows/svn-deploy-assets-on-push.yml
@@ -6,10 +6,17 @@ on:
         paths:
             - .wporg/*
             - readme.txt
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
     master:
         name: Push to master
         runs-on: ubuntu-latest
+        permissions:
+            contents: read # Required for actions/checkout to clone the repository (SVN deploy uses separate SVN credentials, not GITHUB_TOKEN).
         steps:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: WordPress.org plugin asset/readme update

--- a/.github/workflows/svn-deploy-assets-on-push.yml
+++ b/.github/workflows/svn-deploy-assets-on-push.yml
@@ -15,6 +15,7 @@ jobs:
     master:
         name: Push to master
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         permissions:
             contents: read # Required for actions/checkout to clone the repository (SVN deploy uses separate SVN credentials, not GITHUB_TOKEN).
         steps:

--- a/.github/workflows/svn-deploy-plugin-on-release.yml
+++ b/.github/workflows/svn-deploy-plugin-on-release.yml
@@ -13,6 +13,7 @@ jobs:
     deploy:
         name: On Release
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         permissions:
             contents: read # Required for actions/checkout to clone the repository (SVN deploy uses separate SVN credentials, not GITHUB_TOKEN).
         steps:

--- a/.github/workflows/svn-deploy-plugin-on-release.yml
+++ b/.github/workflows/svn-deploy-plugin-on-release.yml
@@ -5,10 +5,16 @@ on:
             - published
             - edited
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
     deploy:
         name: On Release
         runs-on: ubuntu-latest
+        permissions:
+            contents: read # Required for actions/checkout to clone the repository (SVN deploy uses separate SVN credentials, not GITHUB_TOKEN).
         steps:
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -5,10 +5,16 @@ on:
         branches:
             - master
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
     build:
         name: On Push to Master
         runs-on: ubuntu-latest
+        permissions:
+            contents: read # Required for actions/checkout to clone the repository (actions/upload-artifact@v4 does not require GITHUB_TOKEN permissions).
         steps:
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -13,6 +13,7 @@ jobs:
     build:
         name: On Push to Master
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         permissions:
             contents: read # Required for actions/checkout to clone the repository (actions/upload-artifact@v4 does not require GITHUB_TOKEN permissions).
         steps:

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -5,10 +5,16 @@ on:
         types:
             - published
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
     deploy:
         name: On Release
         runs-on: ubuntu-latest
+        permissions:
+            contents: write # Required for actions/upload-release-asset to attach a build artifact to the GitHub release (also covers contents: read for actions/checkout).
         steps:
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -13,6 +13,7 @@ jobs:
     deploy:
         name: On Release
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         permissions:
             contents: write # Required for actions/upload-release-asset to attach a build artifact to the GitHub release (also covers contents: read for actions/checkout).
         steps:


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/newfold-labs/bluehost-site-migrator/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 7 (`cypress.yml`, `lint.yml`, `satis-webhook.yml`, `svn-deploy-assets-on-push.yml`, `svn-deploy-plugin-on-release.yml`, `upload-artifact-on-push.yml`, `upload-asset-on-release.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `bc75312` |
| Timeouts commit | `4167b33` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `cypress.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-webhook.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `svn-deploy-assets-on-push.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `svn-deploy-plugin-on-release.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `upload-artifact-on-push.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `upload-asset-on-release.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| cypress.yml | 1 job was missing a scoped `permissions:` directive | test | `contents: read` [3] — only `actions/checkout` touches the repo; `actions/setup-node`, `actions/cache`, and `actions/upload-artifact@v4` do not require workflow `GITHUB_TOKEN` permissions. |
| lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] — only `actions/checkout` needs token access. |
| satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | webhook | `{}` [3] — `peter-evans/repository-dispatch` uses the `WEBHOOK_TOKEN` secret (a separate PAT), not `GITHUB_TOKEN`; no checkout or other GitHub API calls. |
| svn-deploy-assets-on-push.yml | 1 job was missing a scoped `permissions:` directive | master | `contents: read` [3] — only `actions/checkout`; `bluehost/wp-plugin-readme-assets-updater` authenticates to WP.org SVN with `SVN_USERNAME`/`SVN_PASSWORD`. |
| svn-deploy-plugin-on-release.yml | 1 job was missing a scoped `permissions:` directive | deploy | `contents: read` [3] — only `actions/checkout`; `10up/action-wordpress-plugin-deploy` authenticates to WP.org SVN with `SVN_USERNAME`/`SVN_PASSWORD`. |
| upload-artifact-on-push.yml | 1 job was missing a scoped `permissions:` directive | build | `contents: read` [3] — only `actions/checkout`; `actions/upload-artifact@v4` uses the runtime artifact service, not `GITHUB_TOKEN`. |
| upload-asset-on-release.yml | 1 job was missing a scoped `permissions:` directive | deploy | `contents: write` [3] — `actions/upload-release-asset@v1.0.21` calls the Releases API with `GITHUB_TOKEN` to attach the built ZIP to the release, which requires write access to repository contents; this also covers the `contents: read` needed by `actions/checkout`. |


## Permissions corrections (previously incorrect)

No pre-existing configured `permissions:` were identified as incorrect.


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| cypress.yml | test | `30` | Cypress end-to-end run includes provisioning `wp-env` (Docker), Composer install, yarn build, and the full Cypress suite, so a 30-minute ceiling is a reasonable runaway guard. |
| lint.yml | phpcs | `10` | Composer install plus PHPCS fix/lint is consistently fast; 10 minutes is generous while still catching hangs. |
| satis-webhook.yml | webhook | `5` | Only sets a few env vars and fires a single `repository-dispatch` API call; 5 minutes covers transient network retries. |
| svn-deploy-assets-on-push.yml | master | `15` | Checkout plus an SVN asset/readme sync to WordPress.org; 15 minutes accommodates slower SVN responses without permitting a runaway. |
| svn-deploy-plugin-on-release.yml | deploy | `30` | Performs a full Node/Composer build and then an SVN deploy to WordPress.org, which can be slow on large asset sets. |
| upload-artifact-on-push.yml | build | `30` | Full Node/Composer build plus artifact upload; matches a typical CI build ceiling. |
| upload-asset-on-release.yml | deploy | `30` | Full Node/Composer build, zip, and release-asset upload; 30 minutes provides headroom for the upload step on large packages. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `actions/upload-release-asset@v1.0.21` is officially archived/deprecated upstream. The granted `contents: write` is the documented minimum, but the action itself is a maintenance risk and a switch to `softprops/action-gh-release` (or a `gh release upload` step) would be worth a follow-up PR — out of scope for this audit. |
| 2 | `bluehost/wp-plugin-readme-assets-updater@master` is pinned to a moving `master` ref rather than a commit SHA. Its source was not re-fetched as part of this audit; the assumption that it only uses SVN credentials (no `GITHUB_TOKEN`) is based on its documented purpose and on the workflow not passing a token. Worth verifying and SHA-pinning in a follow-up. |
| 3 | `peter-evans/repository-dispatch@v3.0.0` and `10up/action-wordpress-plugin-deploy@v2.3.0` were assessed from their published behavior (custom `token` input / SVN credentials respectively) — neither consumes `GITHUB_TOKEN` in this workflow. |


